### PR TITLE
update letterSpacing and wordSpacing to accept Strings instead of doubles

### DIFF
--- a/content/en-US/api/textLetterSpacing.md
+++ b/content/en-US/api/textLetterSpacing.md
@@ -11,23 +11,23 @@ browser_compatibility: api.CanvasRenderingContext2D.textLetterSpacing
 
 ## Description
 
-The `textLetterSpacing` property of the `CanvasRenderingContext2D` interface
+The `letterSpacing` property of the `CanvasRenderingContext2D` interface
 returns a double that represents horizontal spacing between characters. 
-Setting `textLetterSpacing` to postive values spreads characters further apart, 
+Setting `letterSpacing` to postive values spreads characters further apart, 
 while negative values brings them closer together. The default value is 0.
 
 ## Syntax
 
-`var textLetterSpacing = CanvasRenderingContext2D.textLetterSpacing`
-`CanvasRenderingContext2D.textLetterSpacing = textLetterSpacing`
+`var letterSpacing = CanvasRenderingContext2D.letterSpacing`
+`CanvasRenderingContext2D.letterSpacing = letterSpacing`
 
 ### Value
 
-A `double` representing horizontal spacing behavior between characters.
+A String representing horizontal spacing behavior between characters.
 
 ### Example
 
-This example demonstrates the various `TextLetterSpacing` property values:
+This example demonstrates the various `letterSpacing` property values:
 
 ```js
 const canvas = document.createElement('canvas');
@@ -35,13 +35,13 @@ canvas.width = 1000;
 canvas.height = 500;
 const ctx = canvas.getContext('2d');
 document.body.appendChild(canvas);
-const letterSpacings = [-2, 0, 4];
+const letterSpacings = ['-2px', '0px', '4px', '1cm', '0.2em', '-0.5mm', '1in'];
 ctx.font = '20px serif';
 
 letterSpacings.forEach(function (letterSpacing, index) {
-  ctx.textLetterSpacing = letterSpacing;
+  ctx.letterSpacing = letterSpacing;
   const y = 50 + index * 50;
-  ctx.fillText('Hello World (textLetterSpacing: ' + letterSpacing + ')', 20, y);
+  ctx.fillText('Hello World (letterSpacing: ' + letterSpacing + ')', 20, y);
 });
 ```
 

--- a/content/en-US/api/textWordSpacing.md
+++ b/content/en-US/api/textWordSpacing.md
@@ -11,24 +11,24 @@ browser_compatibility: api.CanvasRenderingContext2D.textWordSpacing
 
 ## Description
 
-The `textWordSpacing` property of the `CanvasRenderingContext2D` interface
+The `wordSpacing` property of the `CanvasRenderingContext2D` interface
 returns a double that represents horizontal spacing between words.
-Setting `textWordSpacing` to postive values spreads words further apart, 
+Setting `wordSpacing` to postive values spreads words further apart,
 while negative values brings them closer together. The default value 
 is 0.
 
 ## Syntax
 
-`var textWordSpacing = CanvasRenderingContext2D.textWordSpacing`
-`CanvasRenderingContext2D.textWordSpacing = textWordSpacing`
+`var wordSpacing = CanvasRenderingContext2D.wordSpacing`
+`CanvasRenderingContext2D.wordSpacing = wordSpacing`
 
 ### Value
 
-A double representing horizontal spacing behavior between words.
+A String representing horizontal spacing behavior between words.
 
 ### Example
 
-This example demonstrates the various `textWordSpacing` property values:
+This example demonstrates the various `wordSpacing` property values:
 
 ```js
 const canvas = document.createElement('canvas');
@@ -36,13 +36,13 @@ canvas.width = 1000;
 canvas.height = 500;
 const ctx = canvas.getContext('2d');
 document.body.appendChild(canvas);
-const wordSpacings = [-7, 0, 10];
+const wordSpacings = ['-7px', '0px', '7px', '1cm', '0.2em', '-0.5mm', '1in'];
 ctx.font = '20px serif';
 
 wordSpacings.forEach(function (wordSpacing, index) {
-  ctx.textWordSpacing = wordSpacing;
+  ctx.wordSpacing = wordSpacing;
   const y = 50 + index * 50;
-  ctx.fillText('Hello World (textWordSpacing: ' + wordSpacing + ')', 20, y);
+  ctx.fillText('Hello World (wordSpacing: ' + wordSpacing + ')', 20, y);
 });
 ```
 


### PR DESCRIPTION
Update letterSpacing and wordSpacing to accept Strings instead of doubles. So now letterSpacing can be set to 3px, -1em, 1in, -0.5mm, etc. 